### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,16 +11,20 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.valid?
       @item.save
-      redirect_to root_path
+      redirect_to @item
     else
       render 'new'
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
 
   private
-  def item_params
-    params.require(:item).permit(:image, :item_name, :item_text, :category_id, :status_id, :shipping_charger_id, :shipping_origin_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
-  end
-  
+    def item_params
+      params.require(:item).permit(:image, :item_name, :item_text, :category_id, :status_id, :shipping_charger_id, :shipping_origin_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
+    end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <% @items.each do |item| %>
           <li class='list'>
-              <%= link_to "#" do %>
+              <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,109 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.item_name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% if @item.customer %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
+      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= "¥#{@item.price}" %>
+      </span>
+      <span class="item-postage">
+        (税込) 送料込み
+      </span>
+    </div>
+
+    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% elsif @item.customer.blank? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+
+    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
+      <div class="item-explain-box">
+        <span><%= @item.item_text %></span>
+      </div>
+      <table class="detail-table">
+        <tbody>
+          <tr>
+            <th class="detail-item">出品者</th>
+            <td class="detail-value"><%= @item.user.nickname %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">カテゴリー</th>
+            <td class="detail-value"><%= @item.category.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">商品の状態</th>
+            <td class="detail-value"><%= @item.status.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">配送料の負担</th>
+            <td class="detail-value"><%= @item.shipping_charger.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送元の地域</th>
+            <td class="detail-value"><%= @item.shipping_origin.name %></td>
+          </tr>
+          <tr>
+            <th class="detail-item">発送日の目安</th>
+            <td class="detail-value"><%= @item.days_until_shipping.name %></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="option">
+        <div class="favorite-btn">
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <span>お気に入り 0</span>
+        </div>
+        <div class="report-btn">
+          <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+          <span>不適切な商品の通報</span>
+        </div>
+      </div>
+    </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
・ログインの有無に関わらず、商品詳細ページを閲覧可能にするため
・出品者とそれ以外で表示する内容を変えるため。

# 実装の様子（Gyazo）
▼**出品者にしか商品の編集・削除のリンクが踏めない**
   　※購入、編集、削除は未実装のためリンクのクリックは不可 
 ・出品者　購入ボタンなし、編集・削除ボタンあり
　https://gyazo.com/13d490e057418236c2e7342a564bb9ac

・出品者以外　購入ボタンあり、編集・削除ボタンなし
　https://gyazo.com/d9b07c424ac48b0d3dd4051bba6a0a20

▼**売却済みの商品は「sold out」が表示される**
・売却データ入力後、購入ボタンが消える
　https://gyazo.com/41c92f9c2e6eb1e24eb93cd1b426994a

▼**ログアウト状態でも商品詳細ページを閲覧できる**
　https://gyazo.com/d1e78da086d325be2b806d4a30717c5a

▼**商品出品時に登録した情報が見られる**
　https://gyazo.com/13d490e057418236c2e7342a564bb9ac
